### PR TITLE
feat(post): 컨트롤러 로깅 및 어드민 권한 추가

### DIFF
--- a/src/main/java/piq/piqproject/common/error/handle/GlobalExceptionHandler.java
+++ b/src/main/java/piq/piqproject/common/error/handle/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -42,7 +41,6 @@ public class GlobalExceptionHandler {
         public ResponseEntity<ErrorResponseDto> handleCustomExceptionHandler(CustomException e) {
 
                 HttpStatus status = e.getErrorCode().getStatus();
-                int statusCode = e.getErrorCode().getStatus().value();
                 String code = e.getErrorCode().name();
                 String message = e.getMessage();
 

--- a/src/main/java/piq/piqproject/config/springsecurity/SecurityConfig.java
+++ b/src/main/java/piq/piqproject/config/springsecurity/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -24,6 +25,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity // Spring Security를 활성화하고 웹 보안 설정을 구성함을 나타냅니다.
 @RequiredArgsConstructor
+@EnableMethodSecurity
 public class SecurityConfig {
     // JWT 토큰 제공자 및 필터를 주입받습니다.
     private final JwtFilter jwtFilter;

--- a/src/main/java/piq/piqproject/domain/posts/controller/PostController.java
+++ b/src/main/java/piq/piqproject/domain/posts/controller/PostController.java
@@ -2,11 +2,14 @@ package piq.piqproject.domain.posts.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import piq.piqproject.domain.posts.dto.request.AnnouncementRequestDto;
@@ -15,60 +18,91 @@ import piq.piqproject.domain.posts.dto.response.PostResponseDto;
 import piq.piqproject.domain.posts.service.PostService;
 import piq.piqproject.domain.users.entity.UserEntity;
 
-/**
- * TODO: 조회를 제외한 각 메서드에 권한 검증 추가하기 @PreAuthorize("hasRole('ROLE_ADMIN')")
- */
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/posts")
 public class PostController {
         private final PostService postService;
 
+        @PreAuthorize("hasRole('ROLE_ADMIN')")
         @PostMapping("/announcement")
         public ResponseEntity<PostResponseDto> createAnnouncement(
-                        @AuthenticationPrincipal UserEntity user,
-                        @Valid @RequestBody AnnouncementRequestDto announcementRequestDto) {
+                @AuthenticationPrincipal UserEntity user,
+                @Valid @RequestBody AnnouncementRequestDto announcementRequestDto
+        ) {
+                log.info("Request to create an announcement. User: {}", user.getUsername());
+
                 return ResponseEntity.status(201)
                                 .body(postService.createAnnouncement(user.getId(), announcementRequestDto));
         }
 
+        @PreAuthorize("hasRole('ROLE_ADMIN')")
         @PostMapping("/event")
         public ResponseEntity<PostResponseDto> createEvent(
-                        @AuthenticationPrincipal UserEntity user,
-                        @Valid @RequestBody EventRequestDto eventRequestDto) {
+                @AuthenticationPrincipal UserEntity user,
+                @Valid @RequestBody EventRequestDto eventRequestDto
+        ) {
+                log.info("Request to create an event. User: {}", user.getUsername());
+
                 return ResponseEntity.status(201)
                                 .body(postService.createEvent(user.getId(), eventRequestDto));
         }
 
         @GetMapping("/{postId}")
         public ResponseEntity<PostResponseDto> findPost(
-                        @PathVariable("postId") Long postId) {
+                @PathVariable("postId") Long postId
+        ) {
+                log.info("Request to find a single post. Post ID: {}", postId);
+
                 return ResponseEntity.ok(postService.findPost(postId));
         }
 
         @GetMapping("/all")
         public ResponseEntity<Page<PostResponseDto>> getPost(
-                        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+                @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+        ) {
+                log.info("""
+                        Request to get all posts. 
+                        Page number: {}, 
+                        Page size: {}, 
+                        Sort: {}
+                        """, 
+                        pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort()
+                );
+
                 return ResponseEntity.ok(postService.getPost(pageable));
         }
 
+        @PreAuthorize("hasRole('ROLE_ADMIN')")
         @PutMapping("/announcement/{postId}")
         public ResponseEntity<PostResponseDto> updateAnnouncement(
-                        @PathVariable("postId") Long postId,
-                        @Valid @RequestBody AnnouncementRequestDto announcementRequestDto) {
+                @PathVariable("postId") Long postId,
+                @Valid @RequestBody AnnouncementRequestDto announcementRequestDto
+        ) {
+                log.info("Request to update an announcement. Post ID: {}", postId);
+
                 return ResponseEntity.ok(postService.updateAnnouncement(postId, announcementRequestDto));
         }
 
+        @PreAuthorize("hasRole('ROLE_ADMIN')")
         @PutMapping("/event/{postId}")
         public ResponseEntity<PostResponseDto> updateEvent(
-                        @PathVariable("postId") Long postId,
-                        @Valid @RequestBody EventRequestDto eventRequestDto) {
+                @PathVariable("postId") Long postId,
+                @Valid @RequestBody EventRequestDto eventRequestDto
+        ) {
+                log.info("Request to update an event. Post ID: {}", postId);
+
                 return ResponseEntity.ok(postService.updateEvent(postId, eventRequestDto));
         }
 
+        @PreAuthorize("hasRole('ROLE_ADMIN')")
         @PostMapping("/{postId}/delete")
         public ResponseEntity<String> deletePost(
-                        @PathVariable("postId") Long postId) {
+                        @PathVariable("postId") Long postId
+        ) {
+                log.info("Request to delete a post. Post ID: {}", postId);
+
                 postService.deletePost(postId);
                 return ResponseEntity.ok("게시물 삭제에 성공하였습니다.");
         }


### PR DESCRIPTION
## 📝 작업 내역

- [X] 로깅 추가: 각 컨트롤러 메서드 진입 시 요청 정보(사용자, 파라미터 등)를 표시.
- [X] 권한 설정: 게시물 생성, 수정, 삭제 기능은 관리자만 수행할 수 있도록 Spring Security의 `@PreAuthorize`를 통해 접근을 제한


## 💡 PR 특이사항
- 관리자 계정과 일반 사용자 계정으로 모든 Post API에 대한 테스트를 완료
- 이미지 업로드를 포함한 인증/인가 기능이 정상 동작함을 확인


## 📸 스크린샷
### 공지사항 및 이벤트 생성 
<img width="942" height="493" alt="image" src="https://github.com/user-attachments/assets/2327b638-24a3-4a42-a863-bfbce98b0f5a" />

<img width="951" height="504" alt="image" src="https://github.com/user-attachments/assets/8673859e-77c3-488d-b13e-320d26fd096d" />


<br>

### 공지사항 및 이벤트 수정
<img width="956" height="489" alt="image" src="https://github.com/user-attachments/assets/64048237-404a-459c-8cfa-4075af616bb7" />

<img width="939" height="521" alt="image" src="https://github.com/user-attachments/assets/f6b60c85-401c-4e2e-ae45-24badaaf7a16" />

<br>

### 공지사항 및 이벤트 삭제
<img width="950" height="361" alt="image" src="https://github.com/user-attachments/assets/fd299109-b2a0-497a-a2bd-4be99a7c521d" />

<br>

### 공지사항 및 이벤트 조회
<img width="945" height="508" alt="image" src="https://github.com/user-attachments/assets/25359897-1f65-4259-9e5f-6ca48b9836aa" />

<img width="951" height="409" alt="image" src="https://github.com/user-attachments/assets/1c17f4bb-d85f-4bd8-a047-ddca46b66e55" />

<br>

### 접근 제한 
조회를 제외한 모든 Post API요청에 대한 접근이 제한됩니다. 
<img width="955" height="426" alt="image" src="https://github.com/user-attachments/assets/75ca5164-797c-4c0c-b6f9-b7599a68203a" />
